### PR TITLE
Logic error resulting in incorrect condition being entered

### DIFF
--- a/app/code/local/Dwyera/Pinpay/Model/PaymentMethod.php
+++ b/app/code/local/Dwyera/Pinpay/Model/PaymentMethod.php
@@ -312,7 +312,7 @@ class Dwyera_Pinpay_Model_PaymentMethod extends Mage_Payment_Model_Method_Abstra
         $client->setConfig($this->_getHttpConfig());
         $client->setAuth($this->getSecretKey(), '');
 
-        if($requestType == self::REQUEST_TYPE_AUTH_CAPTURE || self::REQUEST_TYPE_AUTH_ONLY) {
+        if($requestType == self::REQUEST_TYPE_AUTH_CAPTURE || $requestType == self::REQUEST_TYPE_AUTH_ONLY) {
             $url .= "charges";
             $client->setMethod($client::POST);
             $requestProps = $request->getData();


### PR DESCRIPTION
@jonpday Stumbled across this error which prevents postponed capture since the wrong API URL would be built when using REQUEST_TYPE_CAPTURE_ONLY. Any delayed capture (i.e. authorize only + manual invoice raising) would fail with a token usage error from PIN.