### PR TITLE
Adds a configurable description prefix to use on the transaction.

### DIFF
--- a/app/code/local/Dwyera/Pinpay/Model/PaymentMethod.php
+++ b/app/code/local/Dwyera/Pinpay/Model/PaymentMethod.php
@@ -21,6 +21,8 @@ class Dwyera_Pinpay_Model_PaymentMethod extends Mage_Payment_Model_Method_Abstra
 
     const CONFIG_FLAG_ENV = 'payment/pinpay/test';
 
+    const CONFIG_PREFIX_DESC = 'payment/pinpay/description_prefix';
+
     /**
      * unique internal payment method identifier
      *
@@ -217,10 +219,16 @@ class Dwyera_Pinpay_Model_PaymentMethod extends Mage_Payment_Model_Method_Abstra
      */
     protected function _buildRequest($payment, $amount, $email)
     {
+        $sDescPrefix = Mage::getStoreConfig(self::CONFIG_PREFIX_DESC);
+
+        if($sDescPrefix){
+            $sDescPrefix .= ' ';
+        }
+
         $request = Mage::getModel('pinpay/request');
         $request->setEmail($email)->
             setAmount($request::getAmountInCents($amount))->
-            setDescription("Quote #:" . $payment->getOrder()->getRealOrderId())->
+            setDescription($sDescPrefix . "Quote #:" . $payment->getOrder()->getRealOrderId())->
             setCardToken($payment->getAdditionalInformation('card_token'))->
             setIpAddress($payment->getOrder()->getRemoteIp());
 

--- a/app/code/local/Dwyera/Pinpay/etc/system.xml
+++ b/app/code/local/Dwyera/Pinpay/etc/system.xml
@@ -97,6 +97,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </payment_action>
+                        <description_prefix translate="label">
+                            <label>Description Prefix</label>
+                            <comment>Additional tag to use in transaction description.</comment>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <sort_order>20</sort_order>
+                            <frontend_type>text</frontend_type>
+                        </description_prefix>
                     </fields>
                 </pinpay>
             </groups>


### PR DESCRIPTION
When multiple Magento sites (either multi-site or multi-install) capture into a single PIN account, an additional description tag can be required for filtering & reporting sales within the PIN dashboard from each individual site.